### PR TITLE
Fixed numeric column indices

### DIFF
--- a/Oci8Statement.php
+++ b/Oci8Statement.php
@@ -578,7 +578,9 @@ class Oci8Statement extends PDOStatement
          * @todo KLUDGE No read column with type ROWID
          */
         foreach ($rs as $name => $value) {
-            if (oci_field_type($this->sth, $name) === 'ROWID') {
+            $ociFieldIndex = is_int($name) ? $name + 1 : $name;
+            
+            if (oci_field_type($this->sth, $ociFieldIndex) === 'ROWID') {
                 $rs[$name] = null;
             }
         }


### PR DESCRIPTION
Add 1 to 0-based numeric indices returned by `foreach` so they are compatible with `oci_field_type()`, which expects 1-based indices.